### PR TITLE
fix: promote `axios` to a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "dependencies": {
+    "axios": "^1.7.3"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.2",
     "@evilmartians/lefthook": "^1.5.0",
@@ -77,7 +80,6 @@
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.44",
-    "axios": "^1.7.3",
     "commitlint": "^17.0.2",
     "del-cli": "^5.1.0",
     "eslint": "^8.51.0",


### PR DESCRIPTION
`axios` is a production dependency of the project but is incorrectly listed as part of `devDependencies`.

cc: @kartikbhalla12 